### PR TITLE
Fix the issues on Windows OS

### DIFF
--- a/src/main/java/net/danlucian/psd2/ing/rpc/Client.java
+++ b/src/main/java/net/danlucian/psd2/ing/rpc/Client.java
@@ -4,7 +4,6 @@ import com.google.gson.Gson;
 import net.danlucian.psd2.ing.exception.rpc.RequestFailure;
 import net.danlucian.psd2.ing.exception.rpc.ResponseFailure;
 import net.danlucian.psd2.ing.security.ClientSecrets;
-import net.danlucian.psd2.ing.time.DateUtil;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -21,8 +20,7 @@ public abstract class Client {
     protected final ClientSecrets clientSecrets;
     protected final String scopes;
 
-    protected final String digest        = generateDigestAndConvert("grant_type=client_credentials");
-    protected final String currentDate   = DateUtil.getCurrentDateAsString();
+    protected final String digest = generateDigestAndConvert("grant_type=client_credentials");
 
     /**
      * @param clientSecrets must not be null
@@ -41,21 +39,21 @@ public abstract class Client {
         this.scopes = "";
     }
 
-    protected String signingTemplate(final String httpVerb, final String uri) {
+    protected String signingTemplate(final String httpVerb, final String uri, final String currentDate) {
         StringWriter stringWriter = new StringWriter();
         PrintWriter printWriter = new PrintWriter(stringWriter);
-        printWriter.println("(request-target): " + httpVerb + " " + uri);
-        printWriter.println("date: " + currentDate);
+        printWriter.print("(request-target): " + httpVerb + " " + uri + "\n");
+        printWriter.print("date: " + currentDate + "\n");
         printWriter.print("digest: " + digest);
 
         return stringWriter.toString();
     }
 
-    protected String signingTemplate(final String httpVerb, String uri, final String customDigest) {
+    protected String signingTemplate(final String httpVerb, final String uri, final String currentDate, final String customDigest) {
         StringWriter stringWriter = new StringWriter();
         PrintWriter printWriter = new PrintWriter(stringWriter);
-        printWriter.println("(request-target): " + httpVerb + " " + uri);
-        printWriter.println("date: " + currentDate);
+        printWriter.print("(request-target): " + httpVerb + " " + uri + "\n");
+        printWriter.print("date: " + currentDate + "\n");
         printWriter.print("digest: " + customDigest);
 
         return stringWriter.toString();

--- a/src/main/java/net/danlucian/psd2/ing/rpc/production/openbanking/AppAccessTokenClient.java
+++ b/src/main/java/net/danlucian/psd2/ing/rpc/production/openbanking/AppAccessTokenClient.java
@@ -5,6 +5,7 @@ import net.danlucian.psd2.ing.rpc.Client;
 import net.danlucian.psd2.ing.rpc.Interceptors;
 import net.danlucian.psd2.ing.rpc.payload.ApplicationAccessToken;
 import net.danlucian.psd2.ing.security.ClientSecrets;
+import net.danlucian.psd2.ing.time.DateUtil;
 import okhttp3.FormBody;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -30,9 +31,10 @@ public class AppAccessTokenClient extends Client implements Interceptors {
     }
 
     public ApplicationAccessToken getToken() throws RequestFailure {
+        final String currentDate = DateUtil.getCurrentDateAsString();
         final String signature = generateSignature(
                 clientSecrets.getClientSigningKey(),
-                signingTemplate("post", "/oauth2/token")
+                signingTemplate("post", "/oauth2/token", currentDate)
         );
         final String authorization = "Signature keyId=\"" + clientId + "\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"" + signature + "\"";
 

--- a/src/main/java/net/danlucian/psd2/ing/rpc/sandbox/AppAccessTokenClient.java
+++ b/src/main/java/net/danlucian/psd2/ing/rpc/sandbox/AppAccessTokenClient.java
@@ -5,6 +5,7 @@ import net.danlucian.psd2.ing.rpc.Client;
 import net.danlucian.psd2.ing.rpc.Interceptors;
 import net.danlucian.psd2.ing.rpc.payload.ApplicationAccessToken;
 import net.danlucian.psd2.ing.security.ClientSecrets;
+import net.danlucian.psd2.ing.time.DateUtil;
 import okhttp3.FormBody;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -27,10 +28,10 @@ public class AppAccessTokenClient extends Client implements Interceptors {
 
     public ApplicationAccessToken getToken() throws RequestFailure {
         final String signatureKeyId = generateSerialNumber(clientSecrets.getClientSigningCert());
-
+        final String currentDate = DateUtil.getCurrentDateAsString();
         final String signature = generateSignature(
                 clientSecrets.getClientSigningKey(),
-                signingTemplate("post", "/oauth2/token")
+                signingTemplate("post", "/oauth2/token",currentDate)
         );
         final String authorization =
                 "Signature keyId=\"SN=" + signatureKeyId + "\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"" + signature + "\"";

--- a/src/main/java/net/danlucian/psd2/ing/rpc/sandbox/AuthorizationServerClient.java
+++ b/src/main/java/net/danlucian/psd2/ing/rpc/sandbox/AuthorizationServerClient.java
@@ -6,6 +6,7 @@ import net.danlucian.psd2.ing.rpc.payload.ApplicationAccessToken;
 import net.danlucian.psd2.ing.rpc.payload.Country;
 import net.danlucian.psd2.ing.rpc.payload.PreflightUrl;
 import net.danlucian.psd2.ing.security.ClientSecrets;
+import net.danlucian.psd2.ing.time.DateUtil;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -43,10 +44,10 @@ public class AuthorizationServerClient extends Client implements Interceptors {
         Objects.requireNonNull(country, "country must not be null");
 
         final String digest = generateDigestAndConvert("");
-
+        final String currentDate = DateUtil.getCurrentDateAsString();
         final String signature = generateSignature(
                 clientSecrets.getClientSigningKey(),
-                signingTemplate("get", "/oauth2/authorization-server-url" + "?scope=" + scopes, digest)
+                signingTemplate("get", "/oauth2/authorization-server-url" + "?scope=" + scopes, currentDate, digest)
         );
         final String authorization =
                 "keyId=\"5ca1ab1e-c0ca-c01a-cafe-154deadbea75\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"" + signature + "\"";

--- a/src/main/java/net/danlucian/psd2/ing/rpc/sandbox/CustomerAccessTokenClient.java
+++ b/src/main/java/net/danlucian/psd2/ing/rpc/sandbox/CustomerAccessTokenClient.java
@@ -5,6 +5,7 @@ import net.danlucian.psd2.ing.rpc.Interceptors;
 import net.danlucian.psd2.ing.rpc.payload.ApplicationAccessToken;
 import net.danlucian.psd2.ing.rpc.payload.CustomerAccessToken;
 import net.danlucian.psd2.ing.security.ClientSecrets;
+import net.danlucian.psd2.ing.time.DateUtil;
 import okhttp3.FormBody;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -38,10 +39,10 @@ public class CustomerAccessTokenClient extends Client implements Interceptors {
         Objects.requireNonNull(authCode, "authCode must not be null");
 
         final String digest = generateDigestAndConvert("grant_type=authorization_code&code=" + authCode + "&redirect_uri=");
-
+        final String currentDate = DateUtil.getCurrentDateAsString();
         final String signature = generateSignature(
                 clientSecrets.getClientSigningKey(),
-                signingTemplate("post", "/oauth2/token", digest)
+                signingTemplate("post", "/oauth2/token", currentDate, digest)
         );
         final String authorization =
                 "keyId=\"5ca1ab1e-c0ca-c01a-cafe-154deadbea75\",algorithm=\"rsa-sha256\",headers=\"(request-target) date digest\",signature=\"" + signature + "\"";

--- a/src/main/java/net/danlucian/psd2/ing/time/DateUtil.java
+++ b/src/main/java/net/danlucian/psd2/ing/time/DateUtil.java
@@ -4,12 +4,13 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 
 final public class DateUtil {
     public static String getCurrentDateAsString() {
         Date date = Calendar.getInstance().getTime();
-        DateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss");
+        DateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss", Locale.US);
         dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
 
         return dateFormat.format(date) + " GMT";


### PR DESCRIPTION
On Windows machines the .println(...) method is using CRLF injection to delimitate a new line and, because of this, the payload used for signing the requests was malformed.

I had to rely only on LF (being Linux/Unix compliant) for signing the requests and this PR fixes the issue.